### PR TITLE
Get current farm count from farm stats url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 
 # db folder
 db/
+
+# pnpm-lock
+pnpm-lock.yaml

--- a/utils/get-farm-data-helper.js
+++ b/utils/get-farm-data-helper.js
@@ -1,0 +1,24 @@
+require('dotenv').config();
+const { getWeekNumber } = require('./get-week-number-helper');
+const axios = require('axios');
+
+const FARM_STATS_URL = process.env.FARM_STATS_URL;
+const GCA_SERVER_URL= process.env.GCA_SERVER_URL;
+
+async function getNumberOfFarms() {
+  const url = FARM_STATS_URL;
+  const data = {
+    urls: [GCA_SERVER_URL],
+    week_number: getWeekNumber(),
+  };
+
+  try {
+    const response = await axios.post(url, data);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching number of farms:', error.message);
+    throw error;
+  }
+}
+
+module.exports = { getNumberOfFarms };

--- a/utils/get-week-number-helper.js
+++ b/utils/get-week-number-helper.js
@@ -1,0 +1,11 @@
+const GENESIS_TIMESTAMP = 1700352000;
+
+function getWeekNumber() {
+  const start = new Date(GENESIS_TIMESTAMP * 1000);
+  const date = new Date();
+  const diff = date.getTime() - start.getTime();
+  const weeks = Math.floor(diff / (1000 * 60 * 60 * 24 * 7));
+  return weeks;
+}
+
+module.exports = { getWeekNumber };


### PR DESCRIPTION
get farm count from farm stats endpoint instead of from glow stats.
also optimize api call in fetchGlowStats by using promise.all